### PR TITLE
Change RabbitMQ connection class

### DIFF
--- a/skyfi_modelship/handler/rabbitmq_handler.py
+++ b/skyfi_modelship/handler/rabbitmq_handler.py
@@ -17,7 +17,7 @@ class RabbitMQHandler:
         config = load_config()
 
         connection = pika.BlockingConnection(
-            pika.ConnectionParameters(config.rabbitmq_host)
+            pika.URLParameters(config.rabbitmq_host)
         )
         channel = connection.channel()
 


### PR DESCRIPTION
This change allows the provisioning of additional parameters to the pika connection.

Example:
```
  connection = pika.BlockingConnection(
              pika.URLParameters('amqp://guest:guest@localhost:5672/?heartbeat=3600')
  )
```